### PR TITLE
getting JWT token fails if URL contains non default port number

### DIFF
--- a/src/GToolkit-Jenkins/JcJenkinsClient.class.st
+++ b/src/GToolkit-Jenkins/JcJenkinsClient.class.st
@@ -49,7 +49,11 @@ JcJenkinsClient >> blueOceanUrl [
 
 { #category : #accessing }
 JcJenkinsClient >> getRootOfUrl [
-	^ url asUrl scheme, '://', url asUrl host.
+	| rootUrl |
+	rootUrl := url asUrl scheme, '://', url asUrl host.
+	^ url asUrl port
+		ifNil: [ rootUrl ]
+		ifNotNil: [:port | rootUrl, ':', port asString ]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
For example when using an url like http://jenkins.myhost:8080 it will try to get the JWT token from http://jenkins.myhost. It seems to be a  problem with JcJenkinsClient>>getRootOfUrl which swallows the port number.

I tested it with an explicit port, plus a http url without a port, plus an https url without a port.